### PR TITLE
bugfix: imageRatio 与 viewRatio 相等并且 contentMode 为 AspectFill 时，没有对 canvas 进行缩放

### DIFF
--- a/src/Canvas/player.js
+++ b/src/Canvas/player.js
@@ -248,7 +248,7 @@ export class Player {
                 else if (this._contentMode === "AspectFit" || this._contentMode === "AspectFill") {
                     const imageRatio = imageSize.width / imageSize.height;
                     const viewRatio = targetSize.width / targetSize.height;
-                    if ((imageRatio >= viewRatio && this._contentMode === "AspectFit") || (imageRatio < viewRatio && this._contentMode === "AspectFill")) {
+                    if ((imageRatio >= viewRatio && this._contentMode === "AspectFit") || (imageRatio <= viewRatio && this._contentMode === "AspectFill")) {
                         const scale = targetSize.width / imageSize.width;
                         const translateX = (imageSize.width * scale - imageSize.width) / 2.0
                         const translateY = (imageSize.height * scale - imageSize.height) / 2.0 + (targetSize.height - imageSize.height * scale) / 2.0


### PR DESCRIPTION
imageRatio 与 viewRatio 相等并且 contentMode 为 AspectFill 时，没有设置 Canvas 的 Transform 属性